### PR TITLE
Updated path for manifest file

### DIFF
--- a/LaravelMixTrait.php
+++ b/LaravelMixTrait.php
@@ -73,7 +73,13 @@ trait LaravelMixTrait
      */
     private function getManifest()
     {
-        $path = webroot_path(static::$manifest);
+        $path = root_path(
+            URL::assemble(
+                Config::get('system.filesystems.themes.root'),
+                Config::get('theming.theme'),
+                static::$manifest
+            )
+        );
 
         return collect(json_decode(File::get($path), true));
     }


### PR DESCRIPTION
Since the mix-manifest.json file is placed in the theme directory, this will correctly load the asset mappings.