### PR TITLE
Added support for Mix manifests in theme directory

### DIFF
--- a/LaravelMixTrait.php
+++ b/LaravelMixTrait.php
@@ -73,8 +73,17 @@ trait LaravelMixTrait
      */
     private function getManifest()
     {
-        $path = webroot_path(static::$manifest);
+        // Get theme path
+        $pathInTheme = webroot_path(URL::assemble(
+            Config::get('system.filesystems.themes.url'),
+            Config::get('theming.theme'),
+            static::$manifest
+        ));
 
-        return collect(json_decode(File::get($path), true));
+        // Get root path
+        $pathInRoot = webroot_path(static::$manifest);
+
+        // Get either theme or root manifest
+        return collect(json_decode(File::get($pathInTheme, File::get($pathInRoot)), true));
     }
 }


### PR DESCRIPTION
The given code example for Laravel Mix is incorrect. Assuming that a `public` directory exists in the Statamic root, the code in [1] would result in a `mix-manifest.json` in `/public/site/themes/theme-name`. Meanwhile, the code in LaravelMixTrait ([2]) tries to locate the manifest as if it were in in `/public/mix-manifest.json`.

[1]:
```js
const laravelMix = require('laravel-mix');

laravelMix
    .setPublicPath('../../../public/site/themes/theme-name')
    .js('js/app.js', '/js/theme-name.js')
    .sass('scss/app.scss', '/css/theme-name.css');
```

[2]:
```php

trait LaravelMixTrait
{
    /**
     * The name of Mix's revision manifest file.
     */
    static $manifest = 'mix-manifest.json';

    // …

    /**
     * Returns the revision manifest contained in a Collection.
     *
     * @return \Illuminate\Support\Collection
     */
    private function getManifest()
    {
        $path = webroot_path(static::$manifest);

        return collect(json_decode(File::get($path), true));
    }
}
```

This change adds support for placing the manifest in the theme file (`<root>/site/themes/theme-name/mix-manifest.json`), but falls back to the old location if none could be found, for those who worked around it before.